### PR TITLE
[#18] 회원 정보 수정, 로그인 검증 로직 추가

### DIFF
--- a/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
+++ b/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
@@ -30,7 +30,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             }
             return true;
         } catch (Exception e) {
-            throw new UnauthorizedException();
+            throw new UnauthorizedException(e);
         }
     }
 

--- a/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
+++ b/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
@@ -1,5 +1,6 @@
 package com.coupang.marketplace.auth;
 
+import com.coupang.marketplace.auth.exception.UnauthorizedException;
 import com.coupang.marketplace.global.constant.SessionKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,15 +19,19 @@ import java.util.Map;
 public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        if (needToAuth((HandlerMethod)handler)) {
-            String userIdBySession = getUserIdBySession(request);
-            String userIdByPath = getUserIdByPathVariable(request);
-            if (!userIdBySession.equals(userIdByPath)) {
-                throw new UnAuthorizedException();
-            };
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws UnauthorizedException {
+        try {
+            if (needToAuth((HandlerMethod)handler)) {
+                String userIdBySession = getUserIdBySession(request);
+                String userIdByPath = getUserIdByPathVariable(request);
+                if (!userIdBySession.equals(userIdByPath)) {
+                    throw new UnauthorizedException();
+                };
+            }
+            return true;
+        } catch (Exception e) {
+            throw new UnauthorizedException();
         }
-        return true;
     }
 
     private boolean needToAuth(HandlerMethod handler){

--- a/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
+++ b/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
@@ -1,0 +1,49 @@
+package com.coupang.marketplace.auth;
+
+import com.coupang.marketplace.global.constant.SessionKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.util.Map;
+
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (needToAuth((HandlerMethod)handler)) {
+            String userIdBySession = getUserIdBySession(request);
+            String userIdByPath = getUserIdByPathVariable(request);
+            if (!userIdBySession.equals(userIdByPath)) {
+                throw new UnAuthorizedException();
+            };
+        }
+        return true;
+    }
+
+    private boolean needToAuth(HandlerMethod handler){
+        if (handler.getMethodAnnotation(AuthRequired.class) == null) {
+            return false;
+        }
+        return true;
+    }
+
+    private String getUserIdBySession(HttpServletRequest request){
+        HttpSession session = request.getSession();
+        return session.getAttribute(SessionKey.LOGIN_USER_ID)
+                .toString();
+    }
+
+    private String getUserIdByPathVariable(HttpServletRequest request){
+        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        return pathVariables.get("id");
+    }
+}

--- a/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
+++ b/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
@@ -1,5 +1,6 @@
 package com.coupang.marketplace.auth;
 
+import com.coupang.marketplace.auth.exception.NoAuthorizationData;
 import com.coupang.marketplace.auth.exception.UnauthorizedException;
 import com.coupang.marketplace.global.constant.SessionKey;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.Map;
+import java.util.Optional;
 
 
 @Component
@@ -43,12 +45,14 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private String getUserIdBySession(HttpServletRequest request){
         HttpSession session = request.getSession();
-        return session.getAttribute(SessionKey.LOGIN_USER_ID)
-                .toString();
+        return Optional.ofNullable(session.getAttribute(SessionKey.LOGIN_USER_ID))
+                .map(v -> v.toString())
+                .orElseThrow(NoAuthorizationData::new);
     }
 
     private String getUserIdByPathVariable(HttpServletRequest request){
         Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        return pathVariables.get("id");
+        return Optional.ofNullable(pathVariables.get("id"))
+                .orElseThrow(NoAuthorizationData::new);
     }
 }

--- a/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
+++ b/src/main/java/com/coupang/marketplace/auth/AuthInterceptor.java
@@ -21,7 +21,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws UnauthorizedException {
         try {
-            if (needToAuth((HandlerMethod)handler)) {
+            if (isNeedToAuth((HandlerMethod)handler)) {
                 String userIdBySession = getUserIdBySession(request);
                 String userIdByPath = getUserIdByPathVariable(request);
                 if (!userIdBySession.equals(userIdByPath)) {
@@ -34,7 +34,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         }
     }
 
-    private boolean needToAuth(HandlerMethod handler){
+    private boolean isNeedToAuth(HandlerMethod handler){
         if (handler.getMethodAnnotation(AuthRequired.class) == null) {
             return false;
         }

--- a/src/main/java/com/coupang/marketplace/auth/AuthRequired.java
+++ b/src/main/java/com/coupang/marketplace/auth/AuthRequired.java
@@ -1,0 +1,12 @@
+package com.coupang.marketplace.auth;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AuthRequired {
+}

--- a/src/main/java/com/coupang/marketplace/auth/UnAuthorizedException.java
+++ b/src/main/java/com/coupang/marketplace/auth/UnAuthorizedException.java
@@ -1,0 +1,4 @@
+package com.coupang.marketplace.auth;
+
+public class UnAuthorizedException extends RuntimeException {
+}

--- a/src/main/java/com/coupang/marketplace/auth/UnAuthorizedException.java
+++ b/src/main/java/com/coupang/marketplace/auth/UnAuthorizedException.java
@@ -1,4 +1,0 @@
-package com.coupang.marketplace.auth;
-
-public class UnAuthorizedException extends RuntimeException {
-}

--- a/src/main/java/com/coupang/marketplace/auth/exception/NoAuthorizationData.java
+++ b/src/main/java/com/coupang/marketplace/auth/exception/NoAuthorizationData.java
@@ -1,0 +1,10 @@
+package com.coupang.marketplace.auth.exception;
+
+public class NoAuthorizationData extends RuntimeException {
+
+    private static final String message = "사용자 인증 정보가 부족합니다.";
+
+    public NoAuthorizationData(){
+        super(message);
+    }
+}

--- a/src/main/java/com/coupang/marketplace/auth/exception/UnauthorizedException.java
+++ b/src/main/java/com/coupang/marketplace/auth/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.coupang.marketplace.auth.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(){
+        super("인증되지 않은 사용자입니다.");
+    }
+}

--- a/src/main/java/com/coupang/marketplace/auth/exception/UnauthorizedException.java
+++ b/src/main/java/com/coupang/marketplace/auth/exception/UnauthorizedException.java
@@ -2,7 +2,13 @@ package com.coupang.marketplace.auth.exception;
 
 public class UnauthorizedException extends RuntimeException {
 
+    private static final String message = "인증되지 않은 사용자입니다.";
+
     public UnauthorizedException(){
-        super("인증되지 않은 사용자입니다.");
+        super(message);
+    }
+
+    public UnauthorizedException(Exception e){
+        super(message, e);
     }
 }

--- a/src/main/java/com/coupang/marketplace/global/config/WebConfig.java
+++ b/src/main/java/com/coupang/marketplace/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.coupang.marketplace.global.config;
+
+import com.coupang.marketplace.auth.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        registry.addInterceptor(new AuthInterceptor());
+    }
+}

--- a/src/main/java/com/coupang/marketplace/global/config/WebConfig.java
+++ b/src/main/java/com/coupang/marketplace/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.coupang.marketplace.global.config;
 
 import com.coupang.marketplace.auth.AuthInterceptor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -10,10 +11,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
+    @Autowired
     private AuthInterceptor authInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry){
-        registry.addInterceptor(new AuthInterceptor());
+        registry.addInterceptor(authInterceptor);
     }
 }

--- a/src/main/java/com/coupang/marketplace/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/coupang/marketplace/global/error/GlobalExceptionHandler.java
@@ -1,31 +1,41 @@
 package com.coupang.marketplace.global.error;
 
+import com.coupang.marketplace.auth.exception.UnauthorizedException;
 import com.coupang.marketplace.global.common.FailResponse;
 import com.coupang.marketplace.global.common.StatusEnum;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<FailResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
-        FailResponse res = FailResponse.builder()
+    public FailResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+        return FailResponse.builder()
                 .status(StatusEnum.BAD_REQUEST)
                 .errorMessage(e.getMessage())
                 .build();
-        return new ResponseEntity<>(res, HttpStatus.BAD_REQUEST);
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<FailResponse> handleIllegalArgumentException(IllegalArgumentException e){
-        FailResponse res = FailResponse.builder()
+    public FailResponse handleIllegalArgumentException(IllegalArgumentException e){
+        return FailResponse.builder()
                 .status(StatusEnum.BAD_REQUEST)
                 .errorMessage(e.getMessage())
                 .build();
-        return new ResponseEntity<>(res, HttpStatus.BAD_REQUEST);
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnauthorizedException.class)
+    public FailResponse handleUnathorizedException(UnauthorizedException e){
+        return FailResponse.builder()
+                .status(StatusEnum.UNAUTHORIZED)
+                .errorMessage(e.getMessage())
+                .build();
     }
 }

--- a/src/main/java/com/coupang/marketplace/user/controller/UserController.java
+++ b/src/main/java/com/coupang/marketplace/user/controller/UserController.java
@@ -1,19 +1,21 @@
 package com.coupang.marketplace.user.controller;
 
+import com.coupang.marketplace.auth.AuthRequired;
 import com.coupang.marketplace.global.common.StatusEnum;
 import com.coupang.marketplace.global.common.SuccessResponse;
+import com.coupang.marketplace.user.controller.dto.*;
 import com.coupang.marketplace.user.service.LoginService;
 import com.coupang.marketplace.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
+
+
+@RequestMapping("/users")
 @RequiredArgsConstructor
 @RestController
 public class UserController {
@@ -21,28 +23,35 @@ public class UserController {
     private final UserService userService;
     private final LoginService loginService;
 
-    @PostMapping("/users/sign-up")
-    public ResponseEntity<SuccessResponse> signUp(@Valid @RequestBody SignUpRequestDto requestDto) {
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/sign-up")
+    public SuccessResponse signUp(@Valid @RequestBody final SignUpRequestDto requestDto) {
         userService.join(requestDto);
         SuccessResponse res = SuccessResponse.builder()
                 .status(StatusEnum.CREATED)
                 .message("회원가입 성공")
                 .build();
-        return new ResponseEntity<>(res, HttpStatus.CREATED);
+        return res;
     }
 
-    @PostMapping("/users/login")
-    public ResponseEntity<SuccessResponse> loginUser(@Valid @RequestBody SignInRequestDto requestDto) {
+    @PostMapping("/login")
+    public SuccessResponse loginUser(@Valid @RequestBody final SignInRequestDto requestDto) {
         loginService.login(requestDto);
         SuccessResponse res = SuccessResponse.builder()
                 .status(StatusEnum.OK)
                 .message("로그인 성공")
                 .build();
-        return new ResponseEntity<>(res, HttpStatus.OK);
+        return res;
     }
 
-    @GetMapping("/users/logout")
+    @GetMapping("/logout")
     public void logoutUser(){
         loginService.logout();
+    }
+
+    @AuthRequired
+    @PutMapping("/{id}")
+    public void updateUser(@PathVariable("id") final long id, @Valid @RequestBody final UpdateUserRequestDto dto, HttpSession httpSession) {
+        userService.updateUser(id, dto);
     }
 }

--- a/src/main/java/com/coupang/marketplace/user/controller/UserController.java
+++ b/src/main/java/com/coupang/marketplace/user/controller/UserController.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
 

--- a/src/main/java/com/coupang/marketplace/user/controller/UserController.java
+++ b/src/main/java/com/coupang/marketplace/user/controller/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
 
     @AuthRequired
     @PutMapping("/{id}")
-    public void updateUser(@PathVariable("id") final long id, @Valid @RequestBody final UpdateUserRequestDto dto, HttpSession httpSession) {
+    public void updateUser(@PathVariable("id") final long id, @Valid @RequestBody final UpdateUserRequestDto dto) {
         userService.updateUser(id, dto);
     }
 }

--- a/src/main/java/com/coupang/marketplace/user/controller/dto/SignInRequestDto.java
+++ b/src/main/java/com/coupang/marketplace/user/controller/dto/SignInRequestDto.java
@@ -1,4 +1,4 @@
-package com.coupang.marketplace.user.controller;
+package com.coupang.marketplace.user.controller.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/coupang/marketplace/user/controller/dto/SignUpRequestDto.java
+++ b/src/main/java/com/coupang/marketplace/user/controller/dto/SignUpRequestDto.java
@@ -1,4 +1,4 @@
-package com.coupang.marketplace.user.controller;
+package com.coupang.marketplace.user.controller.dto;
 
 import com.coupang.marketplace.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/coupang/marketplace/user/controller/dto/UpdateUserRequestDto.java
+++ b/src/main/java/com/coupang/marketplace/user/controller/dto/UpdateUserRequestDto.java
@@ -1,0 +1,39 @@
+package com.coupang.marketplace.user.controller.dto;
+
+import com.coupang.marketplace.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+public class UpdateUserRequestDto {
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @NotBlank(message = "휴대폰 번호를 입력해주세요.")
+    @Pattern(regexp="[0-9]{10,11}", message = "10-11 자리의 전화번호를 입력해야 해요.")
+    private String phone;
+
+    @Builder
+    public UpdateUserRequestDto(String name, String password, String phone) {
+        this.name = name;
+        this.password = password;
+        this.phone = phone;
+    }
+
+    public User toEntity(long id, String salt, String encryptedPassword){
+        return User.builder()
+                .id(id)
+                .name(name)
+                .salt(salt)
+                .password(encryptedPassword)
+                .phone(phone)
+                .build();
+    }
+}

--- a/src/main/java/com/coupang/marketplace/user/domain/EncryptedPassword.java
+++ b/src/main/java/com/coupang/marketplace/user/domain/EncryptedPassword.java
@@ -1,0 +1,17 @@
+package com.coupang.marketplace.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EncryptedPassword {
+
+    private String salt;
+    private String password;
+
+    @Builder
+    public EncryptedPassword(String salt, String password) {
+        this.salt = salt;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/coupang/marketplace/user/repository/UserRepository.java
+++ b/src/main/java/com/coupang/marketplace/user/repository/UserRepository.java
@@ -15,4 +15,5 @@ public interface UserRepository {
 
     Optional<User> findByEmail(String email);
 
+    void updateUser(User user);
 }

--- a/src/main/java/com/coupang/marketplace/user/service/LoginService.java
+++ b/src/main/java/com/coupang/marketplace/user/service/LoginService.java
@@ -1,9 +1,10 @@
 package com.coupang.marketplace.user.service;
 
-import com.coupang.marketplace.user.controller.SignInRequestDto;
+import com.coupang.marketplace.user.controller.dto.SignInRequestDto;
 
 public interface LoginService {
 
     void login(SignInRequestDto dto);
+
     void logout();
 }

--- a/src/main/java/com/coupang/marketplace/user/service/SessionLoginService.java
+++ b/src/main/java/com/coupang/marketplace/user/service/SessionLoginService.java
@@ -1,6 +1,6 @@
 package com.coupang.marketplace.user.service;
 
-import com.coupang.marketplace.user.controller.SignInRequestDto;
+import com.coupang.marketplace.user.controller.dto.SignInRequestDto;
 import com.coupang.marketplace.user.domain.User;
 import com.coupang.marketplace.user.repository.UserRepository;
 import com.coupang.marketplace.global.constant.SessionKey;

--- a/src/main/java/com/coupang/marketplace/user/service/UserService.java
+++ b/src/main/java/com/coupang/marketplace/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.coupang.marketplace.user.service;
 
-import com.coupang.marketplace.user.controller.SignUpRequestDto;
+import com.coupang.marketplace.user.controller.dto.SignUpRequestDto;
+import com.coupang.marketplace.user.controller.dto.UpdateUserRequestDto;
+import com.coupang.marketplace.user.domain.EncryptedPassword;
 import com.coupang.marketplace.user.domain.User;
 import com.coupang.marketplace.user.repository.UserRepository;
 import com.coupang.marketplace.global.util.crypto.CryptoData;
@@ -23,22 +25,33 @@ public class UserService {
             throw new IllegalArgumentException("이미 등록된 메일입니다.");
         }
 
-        String salt = SaltGenerator.generateSalt();
-        CryptoData cryptoData = CryptoData.WithSaltBuilder()
-                .plainText(dto.getPassword())
-                .salt(salt)
-                .build();
-        String encryptedPassword = encryptor.encrypt(cryptoData);
-        User user = dto.toEntity(salt, encryptedPassword);
-
+        EncryptedPassword pw = encryptPasswordWithSalt(dto.getPassword());
+        User user = dto.toEntity(pw.getSalt(), pw.getPassword());
         userRepository.insertUser(user);
     }
 
-    public boolean checkIsUserExist (String email) {
+    private EncryptedPassword encryptPasswordWithSalt(String plainPassword) {
+        String salt = SaltGenerator.generateSalt();
+        CryptoData cryptoData = CryptoData.WithSaltBuilder()
+                .plainText(plainPassword)
+                .salt(salt)
+                .build();
+        String encryptedPassword = encryptor.encrypt(cryptoData);
+        return EncryptedPassword.builder()
+                .salt(salt)
+                .password(encryptedPassword)
+                .build();
+    }
+
+    private boolean checkIsUserExist(String email) {
         return userRepository.findByEmail(email).isPresent();
     }
 
-
+    public void updateUser(long id, UpdateUserRequestDto dto){
+        EncryptedPassword pw = encryptPasswordWithSalt(dto.getPassword());
+        User user = dto.toEntity(id, pw.getSalt(), pw.getPassword());
+        userRepository.updateUser(user);
+    }
 }
 
 

--- a/src/main/resources/mybatis/mapper/UserMapper.xml
+++ b/src/main/resources/mybatis/mapper/UserMapper.xml
@@ -13,7 +13,7 @@
     </select>
     <update id="updateUser" parameterType="User">
         UPDATE USER
-        SET name = #{name}, phone = #{phone}
+        SET name = #{name}, phone = #{phone}, salt = #{salt}, password = #{password}
         WHERE id = #{id}
     </update>
 </mapper>

--- a/src/main/resources/mybatis/mapper/UserMapper.xml
+++ b/src/main/resources/mybatis/mapper/UserMapper.xml
@@ -4,9 +4,16 @@
 
 <mapper namespace="com.coupang.marketplace.user.repository.UserRepository">
     <insert id="insertUser" parameterType="User">
-        INSERT INTO USER (name, email, salt, password, phone) VALUES (#{name}, #{email}, #{salt}, #{password}, #{phone})
+        INSERT INTO USER (name, email, salt, password, phone)
+        VALUES (#{name}, #{email}, #{salt}, #{password}, #{phone})
     </insert>
     <select id="findByEmail" resultType="User">
-        SELECT id, name, email, salt, password, phone FROM USER WHERE email = #{email}
+        SELECT id, name, email, salt, password, phone FROM USER
+        WHERE email = #{email}
     </select>
+    <update id="updateUser" parameterType="User">
+        UPDATE USER
+        SET name = #{name}, phone = #{phone}
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/test/java/com/coupang/marketplace/user/controller/UserControllerTest.java
+++ b/src/test/java/com/coupang/marketplace/user/controller/UserControllerTest.java
@@ -187,7 +187,7 @@ public class UserControllerTest extends ControllerTest {
                 .andDo(print());
     }
 
-    @DisplayName("인증된 사용자면 회원 정보 수정에 실패한다.")
+    @DisplayName("인증되지 않은 사용자면 회원 정보 수정에 실패한다.")
     @Test
     void updateUserByNotAuthenticatedUser() throws Exception {
         // given

--- a/src/test/java/com/coupang/marketplace/user/controller/UserControllerTest.java
+++ b/src/test/java/com/coupang/marketplace/user/controller/UserControllerTest.java
@@ -1,13 +1,17 @@
 package com.coupang.marketplace.user.controller;
 
 import com.coupang.marketplace.fixture.UserFixture.*;
+import com.coupang.marketplace.global.constant.SessionKey;
 import com.coupang.marketplace.user.controller.dto.SignInRequestDto;
 import com.coupang.marketplace.user.controller.dto.SignUpRequestDto;
+import com.coupang.marketplace.user.controller.dto.UpdateUserRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -155,5 +159,53 @@ public class UserControllerTest extends ControllerTest {
         actions
             .andExpect(status().isBadRequest())
             .andDo(print());
+    }
+
+    @DisplayName("인증된 사용자면 회원 정보 수정에 성공한다.")
+    @Test
+    void updateUserByAuthenticatedUser() throws Exception {
+        // given
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(SessionKey.LOGIN_USER_ID, User1.ID);
+
+        final UpdateUserRequestDto dto = UpdateUserRequestDto.builder()
+                .name(User2.NAME)
+                .password(User2.PASSWORD)
+                .phone(User2.PHONE)
+                .build();
+
+        // when
+        final ResultActions actions = mvc.perform(put("/users/{id}", User1.ID)
+                .session(session)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print());
+
+        // then
+        actions
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("인증된 사용자면 회원 정보 수정에 실패한다.")
+    @Test
+    void updateUserByNotAuthenticatedUser() throws Exception {
+        // given
+        final UpdateUserRequestDto dto = UpdateUserRequestDto.builder()
+                .name(User2.NAME)
+                .password(User2.PASSWORD)
+                .phone(User2.PHONE)
+                .build();
+
+        // when
+        final ResultActions actions = mvc.perform(put("/users/{id}", User1.ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print());
+
+        // then
+        actions
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
     }
 }

--- a/src/test/java/com/coupang/marketplace/user/controller/UserControllerTest.java
+++ b/src/test/java/com/coupang/marketplace/user/controller/UserControllerTest.java
@@ -1,6 +1,8 @@
 package com.coupang.marketplace.user.controller;
 
 import com.coupang.marketplace.fixture.UserFixture.*;
+import com.coupang.marketplace.user.controller.dto.SignInRequestDto;
+import com.coupang.marketplace.user.controller.dto.SignUpRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;

--- a/src/test/java/com/coupang/marketplace/user/service/SessionLoginServiceTest.java
+++ b/src/test/java/com/coupang/marketplace/user/service/SessionLoginServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.coupang.marketplace.user.controller.SignInRequestDto;
+import com.coupang.marketplace.user.controller.dto.SignInRequestDto;
 import com.coupang.marketplace.user.domain.User;
 import com.coupang.marketplace.fixture.UserFixture.*;
 import com.coupang.marketplace.user.repository.UserRepository;

--- a/src/test/java/com/coupang/marketplace/user/service/UserServiceTest.java
+++ b/src/test/java/com/coupang/marketplace/user/service/UserServiceTest.java
@@ -1,6 +1,6 @@
 package com.coupang.marketplace.user.service;
 
-import com.coupang.marketplace.user.controller.SignUpRequestDto;
+import com.coupang.marketplace.user.controller.dto.SignUpRequestDto;
 import com.coupang.marketplace.user.domain.User;
 import com.coupang.marketplace.user.repository.UserRepository;
 import com.coupang.marketplace.global.util.crypto.Encryptor;

--- a/src/test/java/com/coupang/marketplace/user/service/UserServiceTest.java
+++ b/src/test/java/com/coupang/marketplace/user/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.coupang.marketplace.user.service;
 
 import com.coupang.marketplace.user.controller.dto.SignUpRequestDto;
+import com.coupang.marketplace.user.controller.dto.UpdateUserRequestDto;
 import com.coupang.marketplace.user.domain.User;
 import com.coupang.marketplace.user.repository.UserRepository;
 import com.coupang.marketplace.global.util.crypto.Encryptor;
@@ -71,5 +72,23 @@ public class UserServiceTest {
 
         // then
         assertThrows(IllegalArgumentException.class, () -> userService.join(dto));
+    }
+
+    @DisplayName("유저에 대한 정보를 수정한다.")
+    @Test
+    void updateUser() {
+        // given
+        final UpdateUserRequestDto dto = UpdateUserRequestDto.builder()
+                .name(User2.NAME)
+                .password(User2.PASSWORD)
+                .phone(User2.PHONE)
+                .build();
+        final long id = User1.ID;
+
+        // when
+        userService.updateUser(id, dto);
+
+        // then
+        then(userRepository).should(times(1)).updateUser(any());
     }
 }


### PR DESCRIPTION
# 변경사항
- 회원 정보 수정 기능 추가
- 로그인 검증 로직 추가
  - interceptor 와 어노테이션을 활용하여 구현하였음
  - `@AuthRequired` 가 붙은 컨트롤러에 대해서 세션과 PathVariable 로 전달되는 id 를 비교하여 로그인하였는지 검증함

# 참고
### SignUpDto 와 UpdateUserDto 의 추상화에 대한 고민
<img src="https://user-images.githubusercontent.com/79824919/128208434-616e1e4a-5dd4-4776-88b9-ad56a8768760.png" width="90%"/>

</br>

이전에 시은님과 위와 같은 논의를 진행하였고, **저는 "완전 분리" 하기로 결정하였습니다!**
실제로 두 개의 `DTO` 가 유사할 수 있다는 생각에는 동의하지만, '두 개의 `DTO` 의 변경이 반드시 동일한 이유로 이루어질 것이냐?' 에 대해서는 동의하기 어렵습니다. 비즈니스 기획에 따라서 둘의 `DTO` 는 독립적으로 달라질 수 있기 때문에, '둘의 공통적인 성질이 어디까지인가'는 예측하기 쉽지 않은 문제입니다.
우리가 `DTO` 를 작성하는 이유는 각각의 API 에 대한 요청 형태를 정의하는 것인데, 서로 다른 API 의 `DTO` 를 결합하면 결국 두 API 사이에 결합이 생깁니다. 한 쪽의 변경이 다른 `DTO` 와 API 에 영향을 주게 되는 것입니다. 따라서, `DTO` 는 고립되어야 한다고 생각합니다.
물론 간단한 서비스에서는 상관없겠지만, 우리는 계속 성장하고 또 변화하는 서비스를 만들고 있기 때문에 유연하게 만드는 것이 확장성에 도움이 될 것 같습니다 😀